### PR TITLE
Switch default branch to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,13 +68,5 @@ jobs:
             fi
           done
 
-      # 2021-02-21: Workarounds to avoid podman warnings that interrupt test output
-      # dbus-launch https://github.com/containers/podman/issues/9353
-      - name: Work around podman warning output
-        run: |
-          sudo apt-get update && sudo apt-get install -y -q dbus-x11
-          sudo sed -i -re 's/[# ]*cgroup_manager = .+/cgroup_manager = "cgroupfs"/' /etc/containers/containers.conf
-          sudo apt-get install --only-upgrade podman
-
       - name: Run tests
         run: pytest -v tests/${{ matrix.repo_type }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 This plugin is still in development and relies on [unreleased features of repo2docker](https://github.com/jupyter/repo2docker/pull/848).
 
     pip install -U git+https://github.com/manics/repo2docker.git@abstractengine
-    pip install -U git+https://github.com/manics/repo2docker-podman.git@master
+    pip install -U git+https://github.com/manics/repo2docker-podman.git@main
 
 ## Running
 


### PR DESCRIPTION
This will also trigger a rerun of the tests following the update of https://github.com/manics/repo2docker/tree/abstractengine in https://github.com/jupyterhub/repo2docker/pull/848

Edit: Looks like an upstream podman change has broken the test setup