### PR TITLE
repo2docker depedency master to main

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     # https://github.com/jupyter/repo2docker/pull/848
     install_requires=[
         "jupyter-repo2docker @ "
-        "git+https://github.com/jupyterhub/repo2docker.git@master"
+        "git+https://github.com/jupyterhub/repo2docker.git@main"
     ],
     python_requires=">=3.5",
     author="Simon Li",


### PR DESCRIPTION
It seems like [https://github.com/jupyterhub/repo2docker](repo2docker) also started using `main` as their default branch, therefore `pip install -U git+https://github.com/manics/repo2docker-podman.git@main` is breaking.