### PR TITLE
Depend on released repo2docker, python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ Requires Podman 3+.
 
 ## Installation
 
-This plugin is still in development and relies on [unreleased features of repo2docker](https://github.com/jupyter/repo2docker/pull/848).
-
-    pip install -U git+https://github.com/jupyterhub/repo2docker.git@master
     pip install -U git+https://github.com/manics/repo2docker-podman.git@main
 
 ## Running

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     name="repo2docker-podman",
     # https://github.com/jupyter/repo2docker/pull/848
     install_requires=["jupyter-repo2docker>=2021.08.0"],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     author="Simon Li",
     url="https://github.com/manics/repo2docker-podman",
     project_urls={"Documentation": "https://repo2docker.readthedocs.io"},

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,7 @@ import setuptools
 setuptools.setup(
     name="repo2docker-podman",
     # https://github.com/jupyter/repo2docker/pull/848
-    install_requires=[
-        "jupyter-repo2docker @ "
-        "git+https://github.com/jupyterhub/repo2docker.git@main"
-    ],
+    install_requires=["jupyter-repo2docker>=2021.08.0"],
     python_requires=">=3.5",
     author="Simon Li",
     url="https://github.com/manics/repo2docker-podman",


### PR DESCRIPTION
https://github.com/jupyter/repo2docker/pull/848 was released in https://github.com/jupyterhub/repo2docker/releases/tag/2021.08.0